### PR TITLE
Add workflow for checking dotenv files to CI

### DIFF
--- a/.github/workflows/dotenv-linter.yaml
+++ b/.github/workflows/dotenv-linter.yaml
@@ -1,0 +1,14 @@
+name: dotenv
+on: [pull_request]
+jobs:
+  dotenv-linter:
+    name: runner / dotenv-linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run dotenv-linter
+        uses: dotenv-linter/action-dotenv-linter@v3
+        with:
+          reporter: github-pr-check
+          dotenv_linter_flags: --recursive
+          fail_level: none

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,1 +1,2 @@
-BOT_TOKEN =
+BOT_TOKEN = <your-token-from-botfather>
+


### PR DESCRIPTION
Right now for every pull request will start workflow, that will always finished, with exit code 0, but if in your dotenv files exists some errors, reviewdog will post a report with checks result. You can fix it and push new commit to branch, for rerun checking again.

Close #25 